### PR TITLE
fix 修改样式，匹配主题色

### DIFF
--- a/packages/example/src/index.css
+++ b/packages/example/src/index.css
@@ -94,6 +94,7 @@ a {
 }
 .btn:disabled {
   opacity: 0.65;
+  cursor: not-allowed;
 }
 .btn:not(:disabled):not(.disabled) {
   cursor: pointer;
@@ -110,7 +111,7 @@ a {
   color: #fff;
 }
 .btn-outline-primary:focus {
-  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(65, 184, 130, 0.3);
 }
 .btn-outline-primary:disabled {
   background-color: transparent;
@@ -212,4 +213,11 @@ a {
 }
 .logo-img {
   max-width: 90%;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto;
 }


### PR DESCRIPTION
1. 优化焦点状态阴影颜色（更匹配主题色）
原代码中 .btn-outline-primary:focus 的阴影颜色使用了蓝色系 rgba(0, 123, 255, 0.5)，与主题色 #41b882（绿色系）不匹配。优化后改为绿色阴影，更贴合主题。
代码位置：
css
.btn-outline-primary:focus {
-  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5);
+  box-shadow: 0 0 0 0.2rem rgba(65, 184, 130, 0.3); /* 65,184,130 是 #41b882 的 RGB 值 */
}

2. 添加 img 标签的默认样式（防止拉伸）
为所有 img 标签添加默认样式，确保图片在不同容器中自动适应宽度，避免拉伸变形。
代码位置：
css
/* 在图片相关样式或全局样式中添加 */
img {
  max-width: 100%; /* 宽度不超过父容器 */
  height: auto;     /* 保持宽高比 */
  display: block;   /* 移除底部间隙 */
  margin: 0 auto;   /* 块级元素居中（可选） */
}
3.为禁用按钮添加 cursor: not-allowed